### PR TITLE
Fix SoTA Elastic Search Query to Have Dynamic Date

### DIFF
--- a/app/actions/fetch_news.js
+++ b/app/actions/fetch_news.js
@@ -1,10 +1,11 @@
 import { FETCH_NEWS, SET_NEWS } from '../constants/action_types';
-import { API_SOTA_ES_QUERY_NEWS } from '../constants/api_endpoints';
+import buildNewsQueryService from '../lib/services/build_news_query_service';
+
 
 const fetchNews = () => ({
   type: FETCH_NEWS,
   payload: {
-    query: API_SOTA_ES_QUERY_NEWS,
+    query: buildNewsQueryService(),
     success: SET_NEWS
   }
 });

--- a/app/constants/api_endpoints.js
+++ b/app/constants/api_endpoints.js
@@ -1,4 +1,7 @@
-import { SOTA_ES_SCENE_STORMS_REACH, SOTA_ES_EVENT_MONSTER_PLAYER } from './defaults';
+import {
+  SOTA_ES_SCENE_STORMS_REACH,
+  SOTA_ES_EVENT_MONSTER_PLAYER
+} from './defaults';
 
 /**
  * API host to application "back end".
@@ -33,5 +36,4 @@ export const API_EXTERNAL_PROXY = 'https://cors-anywhere.herokuapp.com/';
 export const API_ENDPOINT_SOTA_ES_BASE = 'http://www.shroudoftheavatar.com:9200/_all/_search?q=';
 export const API_SOTA_ES_QUERY_NEWS    = `SceneName:${
   SOTA_ES_SCENE_STORMS_REACH}%20AND%20LocationEvent:${
-  SOTA_ES_EVENT_MONSTER_PLAYER}%20AND%20@timestamp:${
-  new Date(Date.now() - (86400000*2)).toISOString().split('T')[0]}`; // "yesterday", YYYY-MM-DD
+  SOTA_ES_EVENT_MONSTER_PLAYER}%20AND%20@timestamp:`;

--- a/app/lib/services/build_news_query_service.js
+++ b/app/lib/services/build_news_query_service.js
@@ -1,0 +1,14 @@
+import { API_SOTA_ES_QUERY_NEWS } from '../../constants/api_endpoints';
+
+/**
+ * Build the dynamic query parameters for the SoTA Elastic Search query, and
+ * return the assembled URL.
+ */
+const buildNewsQueryService = () => {
+  let yesterdaysYYYYMMDD = new Date(Date.now() - (86400000*2))
+    .toISOString()
+    .split('T')[0];
+  return `${API_SOTA_ES_QUERY_NEWS}${yesterdaysYYYYMMDD}`;
+};
+
+export default buildNewsQueryService;

--- a/test/actions/fetch_news.test.js
+++ b/test/actions/fetch_news.test.js
@@ -4,12 +4,13 @@ import * as actionTypes from '../../app/constants/action_types';
 
 describe('Fetch News ActionCreator', () => {
 
-  it('creates fetching of NewsItems action, with query and success action', () => {
+  it('creates fetch NewsItems action, with query and success action', () => {
+    const expectedNewsQuery = stubNewsQueryUrl();
 
     const expectedAction = {
       type: actionTypes.FETCH_NEWS,
       payload: {
-        query: API_SOTA_ES_QUERY_NEWS,
+        query: expectedNewsQuery,
         success: actionTypes.SET_NEWS
       }
     };
@@ -18,3 +19,15 @@ describe('Fetch News ActionCreator', () => {
   });
 
 });
+
+const stubNewsQueryUrl = () => {
+  const buildNewsQueryServiceMock = jest.fn();
+  buildNewsQueryServiceMock.mockReturnValue(
+    API_SOTA_ES_QUERY_NEWS + (new Date(Date.now() - (86400000*2))
+      .toISOString()
+      .split('T')[0]
+    )
+  );
+
+  return buildNewsQueryServiceMock();
+};

--- a/test/services/build_news_query_service.test.js
+++ b/test/services/build_news_query_service.test.js
@@ -1,0 +1,16 @@
+import { API_SOTA_ES_QUERY_NEWS } from '../../app/constants/api_endpoints';
+import
+  buildNewsQueryService
+  from '../../app/lib/services/build_news_query_service';
+
+describe('function buildNewsQueryService()', () => {
+  it('appends yesterday\'s date in YYYY-MM-DD format to the query URL', () => {
+    const yesterdaysYYYYMMDDstring = new Date(Date.now() - (86400000*2))
+      .toISOString()
+      .split('T')[0];
+    const expectedNewsQueryURL = API_SOTA_ES_QUERY_NEWS +
+      yesterdaysYYYYMMDDstring;
+
+    expect(buildNewsQueryService()).toEqual(expectedNewsQueryURL);
+  });
+});


### PR DESCRIPTION
* Create new service object to dynamically allocate "yesterday" to the
  SoTA ES query URL.
* Create tests